### PR TITLE
Constrain linopy correctly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   script: '{{ PYTHON }} -m pip install . -vvv '
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pytables
     - deprecation
     - xarray
-    - linopy <=0.1
+    - linopy <0.1
 
 test:
   imports:


### PR DESCRIPTION
linopy v0.1 is released and needs adaption.

@conda-forge-admin, please rerender